### PR TITLE
사용 된 단어를 보여주는 기능 추가

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -43,6 +43,8 @@ class Worker(QThread):
                 self.parent.Word.setText(r_w)
                 self.parent.Description.setText(r_e)
                 self.parent.System_m.setText("[System] : 잠시만 기다려주세요..")
+                self.parent.word_list.addItem(w)
+
                 time.sleep(1)
                 self.parent.user_turn = False
                 result, word = choose_word(w[len(w) - 1], self.parent.used)
@@ -52,6 +54,8 @@ class Worker(QThread):
                     self.parent.Description.setText(word[1])
                     self.parent.user_turn = True
                     self.parent.s = word[0][len(word[0]) - 1]
+                    self.parent.word_list.addItem(word[0])
+
                     self.parent.System_m.setText(f"[System] : \"{self.parent.s}\"로 시작하는 단어를 입력해주세요")
                 else:
                     self.parent.System_m.setText("[System] : 승리하셨습니다! \n Enter를 눌러 다시 시작해주세요.")
@@ -59,6 +63,8 @@ class Worker(QThread):
         else:
             self.parent.Word.clear()
             self.parent.Description.clear()
+            self.parent.word_list.clear()
+
             self.parent.status = True
             self.parent.s = random.choice(["가", "나", "다", "라", "마"])   # 배열 안에 넣고 싶은 단어를 넣어주세요
             self.parent.System_m.setText(f"[System] : 다음 단어로 끝말잇기를 해주세요 \"{self.parent.s}\" "
@@ -79,6 +85,10 @@ class SangToGUI(QWidget, form):
         self.sendButton.clicked.connect(self.sendMessage)
         self.TextEditor.returnPressed.connect(self.sendMessage)
         self.Description.setWordWrap(True)
+
+        self.vscrollbar = self.word_list.verticalScrollBar()
+        self.vscrollbar.rangeChanged.connect(lambda m, x: self.vscrollbar.setValue(x)) # Auto Scrolling
+
         self.setCenter()
         self.show()
 

--- a/systemUI.ui
+++ b/systemUI.ui
@@ -9,7 +9,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>384</width>
+    <width>500</width>
     <height>313</height>
    </rect>
   </property>
@@ -21,7 +21,7 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>384</width>
+    <width>500</width>
     <height>313</height>
    </size>
   </property>
@@ -49,73 +49,101 @@
     <enum>QLayout::SetMaximumSize</enum>
    </property>
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout_2" stretch="1,1,1,0,0">
+    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,0,9">
      <property name="spacing">
-      <number>1</number>
+      <number>7</number>
      </property>
      <property name="sizeConstraint">
       <enum>QLayout::SetMaximumSize</enum>
      </property>
-     <property name="leftMargin">
-      <number>0</number>
-     </property>
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
      <item>
-      <widget class="QLabel" name="Word">
-       <property name="lineWidth">
-        <number>1</number>
+      <widget class="QListWidget" name="word_list">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Ignored" vsizetype="Ignored">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <property name="text">
-        <string/>
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
        </property>
-       <property name="margin">
+       <property name="font">
+        <font>
+         <pointsize>7</pointsize>
+        </font>
+       </property>
+       <property name="cursor" stdset="0">
+        <cursorShape>IBeamCursor</cursorShape>
+       </property>
+       <property name="locale">
+        <locale language="Korean" country="SouthKorea"/>
+       </property>
+       <property name="verticalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Line" name="line">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_2" stretch="1,1,1,0">
+       <property name="spacing">
+        <number>3</number>
+       </property>
+       <property name="sizeConstraint">
+        <enum>QLayout::SetMaximumSize</enum>
+       </property>
+       <property name="leftMargin">
         <number>0</number>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="Description">
-       <property name="text">
-        <string/>
+       <property name="topMargin">
+        <number>0</number>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="System_m">
-       <property name="whatsThis">
-        <string>System</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="Line" name="line_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <property name="spacing">
-        <number>1</number>
+       <property name="rightMargin">
+        <number>0</number>
        </property>
        <item>
-        <widget class="QLineEdit" name="TextEditor"/>
+        <widget class="QLabel" name="Word">
+        </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="sendButton">
-         <property name="text">
-          <string>입력</string>
+        <widget class="QLabel" name="Description">
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="System_m">
+         <property name="whatsThis">
+          <string>System</string>
          </property>
         </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="spacing">
+          <number>1</number>
+         </property>
+         <item>
+          <widget class="QLineEdit" name="TextEditor"/>
+         </item>
+         <item>
+          <widget class="QPushButton" name="sendButton">
+           <property name="text">
+            <string>입력</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </item>


### PR DESCRIPTION
사용 된 단어를 보여주는 기능을 추가 했습니다.

새로 만든 horizontalLayout_3에 기존 verticalLayout_2를 상속 시키고 QListWidget를 추가하여 
왼편의 단어 목록이, 오른편에 기존 폼이 보이도록 UI를 재배치 했습니다.

**이 기능은 사용자가 입력한 체크 완료 된 단어와 프로그램이 반환하는 단어를 QListWidget의 마지막에 추가합니다.**
```
self.parent.word_list.addItem(w)
```


#### UI 변경 전
```
Form
    - verticalLayout_2
        - verticalLayout_2
        ...
```


#### UI 변경 후
```
Form
    - horizontalLayout_3
        - verticalLayout_2           <---- 기존 폼
            - verticalLayout_2
            ...

        + line (VerticalLine)        <---- 추가
        + word_list (QListWidget) 
```
